### PR TITLE
Add library.json for PlatformIO library manager

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,11 @@
+{
+  "name": "SdFat",
+  "keywords": "sd, card, file, system",
+  "description": "Arduino FAT16/FAT32 Library",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/greiman/SdFat.git"
+  },
+  "include": "SdFat"
+}


### PR DESCRIPTION
This will make SdFat easy to find using [PlatformIO's library manager](http://docs.platformio.org/en/latest/librarymanager/index.html).