### PR TITLE
Allow external project to decide on LFN

### DIFF
--- a/SdFat/src/SdFatConfig.h
+++ b/SdFat/src/SdFatConfig.h
@@ -46,7 +46,9 @@
  *  * (asterisk)
  *
  */
+#ifndef USE_LONG_FILE_NAMES
 #define USE_LONG_FILE_NAMES 1
+#endif
 //------------------------------------------------------------------------------
 /**
  * Set ARDUINO_FILE_USES_STREAM nonzero to use Stream as the base class


### PR DESCRIPTION
If there are more projects using SdFat library, and some of them need LFN=0 while others need LFN=1, you must modify SdFatConfig.h on disk before recompiling each of the projects. The proposed change will allow an external project to define the default behaviour by defining USE_LONG_FILE_NAMES by itself.