### PR TITLE
Update SdSpiSTM32F1.cpp

### DIFF
--- a/src/SpiDriver/SdSpiSTM32F1.cpp
+++ b/src/SpiDriver/SdSpiSTM32F1.cpp
@@ -111,7 +111,7 @@ void SdSpiAltDriver::send(const uint8_t* buf , size_t n) {
 #if USE_STM32F1_DMAC
   pSpi[m_spiPort]->dmaSend(const_cast<uint8*>(buf), n);
 #else  // #if USE_STM32F1_DMAC
-  pSpi[m_spiPort]->write(buf, n);
+  pSpi[m_spiPort]->write((uint8_t*)buf, n);
 #endif  // USE_STM32F1_DMAC
 }
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
- cast the passed buffer type for non-DMA data send (see: http://stm32duino.com/viewtopic.php?f=9&t=2425&p=34461#p34461)