### PR TITLE
Update SdSpiSTM32.cpp

### DIFF
--- a/src/SpiDriver/SdSpiSTM32.cpp
+++ b/src/SpiDriver/SdSpiSTM32.cpp
@@ -93,7 +93,7 @@ uint8_t SdSpiAltDriver::receive(uint8_t* buf, size_t n) {
  * \param[in] b Byte to send
  */
 void SdSpiAltDriver::send(uint8_t b) {
-  m_spi->transfer(b);
+  m_spi->write(b);
 }
 //------------------------------------------------------------------------------
 /** Send multiple bytes.


### PR DESCRIPTION
replaced transfer() by write() - it is suggested to use this function because no reading is needed and is therefore more efficient than transfer().