### PR TITLE
Optionally bracket all library with namespace

### DIFF
--- a/examples/#attic/AnalogLogger/AnalogLogger.ino
+++ b/examples/#attic/AnalogLogger/AnalogLogger.ino
@@ -5,6 +5,10 @@
 #include "sdios.h"
 #include "FreeStack.h"
 
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 #define SD_CHIP_SELECT  SS  // SD chip select pin
 #define USE_DS1307       0  // set nonzero to use DS1307 RTC
 #define LOG_INTERVAL  1000  // mills between entries

--- a/examples/#attic/BaseExtCaseTest/BaseExtCaseTest.ino
+++ b/examples/#attic/BaseExtCaseTest/BaseExtCaseTest.ino
@@ -4,6 +4,10 @@
 #include <SPI.h>
 #include "SdFat.h"
 
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 const uint8_t chipSelect = SS;
 
 SdFat sd;

--- a/examples/#attic/HelloWorld/HelloWorld.ino
+++ b/examples/#attic/HelloWorld/HelloWorld.ino
@@ -2,6 +2,10 @@
 #include "SdFat.h"
 #include "sdios.h"
 
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 //  create a serial output stream
 ArduinoOutStream cout(Serial);
 

--- a/examples/#attic/MiniSerial/MiniSerial.ino
+++ b/examples/#attic/MiniSerial/MiniSerial.ino
@@ -10,6 +10,10 @@
 #ifdef UDR0  // Must be AVR with serial port zero.
 #include "MinimumSerial.h"
 
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 MinimumSerial MiniSerial;
 
 void setup() {

--- a/examples/#attic/PrintBenchmarkSD/PrintBenchmarkSD.ino
+++ b/examples/#attic/PrintBenchmarkSD/PrintBenchmarkSD.ino
@@ -4,6 +4,10 @@
 #include <SPI.h>
 #include <SD.h>
 
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 // SD chip select pin
 const uint8_t chipSelect = SS;
 

--- a/examples/#attic/SD_Size/SD_Size.ino
+++ b/examples/#attic/SD_Size/SD_Size.ino
@@ -5,6 +5,10 @@
 #include <SPI.h>
 #include <SD.h>
 
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 File file;
 //------------------------------------------------------------------------------
 void setup() {

--- a/examples/#attic/SdFatSize/SdFatSize.ino
+++ b/examples/#attic/SdFatSize/SdFatSize.ino
@@ -6,6 +6,10 @@
 #include <SPI.h>
 #include "SdFat.h"
 
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 SdFat sd;
 
 SdFile file;

--- a/examples/#attic/StreamParseInt/StreamParseInt.ino
+++ b/examples/#attic/StreamParseInt/StreamParseInt.ino
@@ -2,6 +2,11 @@
 #include <SPI.h>
 // The next two lines replace #include <SD.h>.
 #include "SdFat.h"
+
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 SdFat SD;
 
 // SD card chip select pin - Modify the value of csPin for your SD module.

--- a/examples/#attic/append/append.ino
+++ b/examples/#attic/append/append.ino
@@ -9,6 +9,10 @@
 #include "SdFat.h"
 #include "sdios.h"
 
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 // SD chip select pin
 const uint8_t chipSelect = SS;
 

--- a/examples/#attic/average/average.ino
+++ b/examples/#attic/average/average.ino
@@ -5,6 +5,10 @@
 #include "SdFat.h"
 #include "sdios.h"
 
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 // SD chip select pin
 const uint8_t chipSelect = SS;
 

--- a/examples/#attic/benchSD/benchSD.ino
+++ b/examples/#attic/benchSD/benchSD.ino
@@ -5,6 +5,10 @@
 #include <SPI.h>
 #include <SD.h>
 
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 // SD chip select pin
 const uint8_t chipSelect = SS;
 

--- a/examples/#attic/bufstream/bufstream.ino
+++ b/examples/#attic/bufstream/bufstream.ino
@@ -5,6 +5,10 @@
 #include "SdFat.h"
 #include "sdios.h"
 
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 // create a serial output stream
 ArduinoOutStream cout(Serial);
 //------------------------------------------------------------------------------

--- a/examples/#attic/cin_cout/cin_cout.ino
+++ b/examples/#attic/cin_cout/cin_cout.ino
@@ -5,6 +5,10 @@
 #include "SdFat.h"
 #include "sdios.h"
 
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 // create serial output stream
 ArduinoOutStream cout(Serial);
 

--- a/examples/#attic/eventlog/eventlog.ino
+++ b/examples/#attic/eventlog/eventlog.ino
@@ -4,6 +4,11 @@
 #include <SPI.h>
 #include "SdFat.h"
 #include "sdios.h"
+
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 // SD chip select pin
 const uint8_t chipSelect = SS;
 

--- a/examples/#attic/fgetsRewrite/fgetsRewrite.ino
+++ b/examples/#attic/fgetsRewrite/fgetsRewrite.ino
@@ -3,6 +3,10 @@
 #include "SdFat.h"
 #include "sdios.h"
 
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 // SD card chip select pin
 const uint8_t chipSelect = SS;
 

--- a/examples/#attic/readlog/readlog.ino
+++ b/examples/#attic/readlog/readlog.ino
@@ -6,6 +6,10 @@
 #include "SdFat.h"
 #include "sdios.h"
 
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 // SD chip select pin
 const uint8_t chipSelect = SS;
 

--- a/examples/AnalogBinLogger/AnalogBinLogger.ino
+++ b/examples/AnalogBinLogger/AnalogBinLogger.ino
@@ -24,6 +24,11 @@
 #include "SdFat.h"
 #include "FreeStack.h"
 #include "AnalogBinLogger.h"
+
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 //------------------------------------------------------------------------------
 // Analog pin number list for a sample.  Pins may be in any order and pin
 // numbers may be repeated.

--- a/examples/DirectoryFunctions/DirectoryFunctions.ino
+++ b/examples/DirectoryFunctions/DirectoryFunctions.ino
@@ -4,6 +4,11 @@
 #include <SPI.h> 
 #include "SdFat.h"
 #include "sdios.h"
+
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 // SD card chip select pin.
 const uint8_t chipSelect = SS;
 //------------------------------------------------------------------------------

--- a/examples/LongFileName/LongFileName.ino
+++ b/examples/LongFileName/LongFileName.ino
@@ -5,6 +5,10 @@
 #include "SdFat.h"
 #include "FreeStack.h"
 
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 // SD card chip select pin.
 const uint8_t SD_CS_PIN = SS;
 

--- a/examples/LowLatencyLogger/LowLatencyLogger.ino
+++ b/examples/LowLatencyLogger/LowLatencyLogger.ino
@@ -18,11 +18,16 @@
 #include "FreeStack.h"
 #include "UserTypes.h"
 
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 #ifdef __AVR_ATmega328P__
 #include "MinimumSerial.h"
 MinimumSerial MinSerial;
 #define Serial MinSerial
 #endif  // __AVR_ATmega328P__
+
 //==============================================================================
 // Start of configuration constants.
 //==============================================================================

--- a/examples/LowLatencyLogger/UserFunctions.cpp
+++ b/examples/LowLatencyLogger/UserFunctions.cpp
@@ -1,6 +1,10 @@
 #include "UserTypes.h"
 // User data functions.  Modify these functions for your data items.
 
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 // Start time for data
 static uint32_t startMicros;
 

--- a/examples/LowLatencyLoggerADXL345/LowLatencyLogger.ino
+++ b/examples/LowLatencyLoggerADXL345/LowLatencyLogger.ino
@@ -18,11 +18,16 @@
 #include "FreeStack.h"
 #include "UserTypes.h"
 
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 #ifdef __AVR_ATmega328P__
 #include "MinimumSerial.h"
 MinimumSerial MinSerial;
 #define Serial MinSerial
 #endif  // __AVR_ATmega328P__
+
 //==============================================================================
 // Start of configuration constants.
 //==============================================================================

--- a/examples/LowLatencyLoggerADXL345/UserFunctions.cpp
+++ b/examples/LowLatencyLoggerADXL345/UserFunctions.cpp
@@ -1,6 +1,10 @@
 #include "UserTypes.h"
 // User data functions.  Modify these functions for your data items.
 
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 // Start time for data
 static uint32_t startMicros;
 

--- a/examples/LowLatencyLoggerMPU6050/LowLatencyLogger.ino
+++ b/examples/LowLatencyLoggerMPU6050/LowLatencyLogger.ino
@@ -18,11 +18,16 @@
 #include "FreeStack.h"
 #include "UserTypes.h"
 
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 #ifdef __AVR_ATmega328P__
 #include "MinimumSerial.h"
 MinimumSerial MinSerial;
 #define Serial MinSerial
 #endif  // __AVR_ATmega328P__
+
 //==============================================================================
 // Start of configuration constants.
 //==============================================================================

--- a/examples/LowLatencyLoggerMPU6050/UserFunctions.cpp
+++ b/examples/LowLatencyLoggerMPU6050/UserFunctions.cpp
@@ -3,6 +3,11 @@
 #include "Wire.h"
 #include "I2Cdev.h"
 #include "MPU6050.h"
+
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 //------------------------------------------------------------------------------
 MPU6050 mpu;
 static uint32_t startMicros;

--- a/examples/OpenNext/OpenNext.ino
+++ b/examples/OpenNext/OpenNext.ino
@@ -4,6 +4,10 @@
 #include <SPI.h>
 #include "SdFat.h"
 
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 // SD default chip select pin.
 const uint8_t chipSelect = SS;
 

--- a/examples/PrintBenchmark/PrintBenchmark.ino
+++ b/examples/PrintBenchmark/PrintBenchmark.ino
@@ -6,6 +6,10 @@
 #include "sdios.h"
 #include "FreeStack.h"
 
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 // SD chip select pin
 const uint8_t chipSelect = SS;
 

--- a/examples/QuickStart/QuickStart.ino
+++ b/examples/QuickStart/QuickStart.ino
@@ -3,6 +3,11 @@
 #include <SPI.h>
 #include "SdFat.h"
 #include "sdios.h"
+
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 //
 // Set DISABLE_CHIP_SELECT to disable a second SPI device.
 // For example, with the Ethernet shield, set DISABLE_CHIP_SELECT

--- a/examples/RawWrite/RawWrite.ino
+++ b/examples/RawWrite/RawWrite.ino
@@ -15,6 +15,10 @@
 #include "sdios.h"
 #include "FreeStack.h"
 
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 // SD chip select pin
 const uint8_t chipSelect = SS;
 

--- a/examples/ReadCsv/ReadCsv.ino
+++ b/examples/ReadCsv/ReadCsv.ino
@@ -9,6 +9,11 @@
 
 // next two lines for SdFat
 #include <SdFat.h>
+
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 SdFat SD;
 
 #define CS_PIN SS

--- a/examples/ReadCsvArray/ReadCsvArray.ino
+++ b/examples/ReadCsvArray/ReadCsvArray.ino
@@ -8,6 +8,10 @@
 #define ROW_DIM 5
 #define COL_DIM 4
 
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 SdFat SD;
 File file;
 

--- a/examples/ReadCsvStream/ReadCsvStream.ino
+++ b/examples/ReadCsvStream/ReadCsvStream.ino
@@ -6,6 +6,10 @@
 #include "SdFat.h"
 #include "sdios.h"
 
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 // SD chip select pin
 const uint8_t chipSelect = SS;
 

--- a/examples/ReadWrite/ReadWrite.ino
+++ b/examples/ReadWrite/ReadWrite.ino
@@ -20,6 +20,11 @@
 #include <SPI.h>
 //#include <SD.h>
 #include "SdFat.h"
+
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 SdFat SD;
 
 #define SD_CS_PIN SS

--- a/examples/STM32Test/STM32Test.ino
+++ b/examples/STM32Test/STM32Test.ino
@@ -6,6 +6,10 @@
 #include "SdFat.h"
 #include "FreeStack.h"
 
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 // set ENABLE_EXTENDED_TRANSFER_CLASS non-zero to use faster EX classes
 
 // Use first SPI port

--- a/examples/SdFormatter/SdFormatter.ino
+++ b/examples/SdFormatter/SdFormatter.ino
@@ -35,6 +35,10 @@ const uint8_t chipSelect = SS;
 #include "FreeStack.h"
 #endif  // DEBUG_PRINT
 
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 // Serial output stream
 ArduinoOutStream cout(Serial);
 

--- a/examples/SdInfo/SdInfo.ino
+++ b/examples/SdInfo/SdInfo.ino
@@ -5,6 +5,10 @@
 #include "SdFat.h"
 #include "sdios.h"
 
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 // Set USE_SDIO to zero for SPI card access. 
 #define USE_SDIO 0
 /*

--- a/examples/SoftwareSpi/SoftwareSpi.ino
+++ b/examples/SoftwareSpi/SoftwareSpi.ino
@@ -5,6 +5,11 @@
 //
 #include <SPI.h>
 #include "SdFat.h"
+
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 #if ENABLE_SOFTWARE_SPI_CLASS  // Must be set in SdFat/SdFatConfig.h
 //
 // Pin numbers in templates must be constants.

--- a/examples/StdioBench/StdioBench.ino
+++ b/examples/StdioBench/StdioBench.ino
@@ -2,6 +2,10 @@
 #include <SPI.h>
 #include "SdFat.h"
 
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 // Define PRINT_FIELD nonzero to use printField.
 #define PRINT_FIELD 0
 

--- a/examples/TeensySdioDemo/TeensySdioDemo.ino
+++ b/examples/TeensySdioDemo/TeensySdioDemo.ino
@@ -7,6 +7,10 @@
 
 #include "SdFat.h"
 
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 // 32 KiB buffer.
 const size_t BUF_DIM = 32768;
 

--- a/examples/Timestamp/Timestamp.ino
+++ b/examples/Timestamp/Timestamp.ino
@@ -6,6 +6,10 @@
 #include "SdFat.h"
 #include "sdios.h"
 
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 SdFat sd;
 
 SdFile file;

--- a/examples/TwoCards/TwoCards.ino
+++ b/examples/TwoCards/TwoCards.ino
@@ -6,6 +6,10 @@
 #include "SdFat.h"
 #include "FreeStack.h"
 
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 SdFat sd1;
 const uint8_t SD1_CS = 10;  // chip select for sd1
 

--- a/examples/VolumeFreeSpace/VolumeFreeSpace.ino
+++ b/examples/VolumeFreeSpace/VolumeFreeSpace.ino
@@ -4,6 +4,11 @@
 #include <SPI.h>
 #include "SdFat.h"
 #include "sdios.h"
+
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 /*
  * SD chip select pin.  Common values are:
  *

--- a/examples/bench/bench.ino
+++ b/examples/bench/bench.ino
@@ -6,6 +6,10 @@
 #include "sdios.h"
 #include "FreeStack.h"
 
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 // Set USE_SDIO to zero for SPI card access. 
 #define USE_SDIO 0
 

--- a/examples/dataLogger/dataLogger.ino
+++ b/examples/dataLogger/dataLogger.ino
@@ -4,6 +4,10 @@
 #include <SPI.h>
 #include "SdFat.h"
 
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 // SD chip select pin.  Be sure to disable any other SPI devices such as Enet.
 const uint8_t chipSelect = SS;
 

--- a/examples/fgets/fgets.ino
+++ b/examples/fgets/fgets.ino
@@ -3,6 +3,10 @@
 #include "SdFat.h"
 #include "sdios.h"
 
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 // SD chip select pin
 const uint8_t chipSelect = SS;
 

--- a/examples/formatting/formatting.ino
+++ b/examples/formatting/formatting.ino
@@ -6,6 +6,10 @@
 #include "SdFat.h"
 #include "sdios.h"
 
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 // create Serial stream
 ArduinoOutStream cout(Serial);
 //------------------------------------------------------------------------------

--- a/examples/getline/getline.ino
+++ b/examples/getline/getline.ino
@@ -10,6 +10,10 @@
 #include "SdFat.h"
 #include "sdios.h"
 
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 // SD chip select pin
 const uint8_t chipSelect = SS;
 

--- a/examples/rename/rename.ino
+++ b/examples/rename/rename.ino
@@ -6,6 +6,10 @@
 #include "SdFat.h"
 #include "sdios.h"
 
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 // SD chip select pin
 const uint8_t chipSelect = SS;
 

--- a/examples/wipe/wipe.ino
+++ b/examples/wipe/wipe.ino
@@ -1,6 +1,11 @@
 // Example to wipe all data from an already formatted SD.
 #include <SPI.h>
 #include "SdFat.h"
+
+#ifdef SDFAT_NAMESPACE
+using namespace sdfat;
+#endif
+
 const int chipSelect = SS;
 
 SdFat sd;

--- a/src/BlockDriver.h
+++ b/src/BlockDriver.h
@@ -30,6 +30,10 @@
 #define BlockDriver_h
 #include "FatLib/BaseBlockDriver.h"
 #include "SdCard/SdSpiCard.h"
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
 //-----------------------------------------------------------------------------
 /** typedef for BlockDriver */
 #if ENABLE_EXTENDED_TRANSFER_CLASS || ENABLE_SDIO_CLASS
@@ -37,4 +41,9 @@ typedef BaseBlockDriver BlockDriver;
 #else  // ENABLE_EXTENDED_TRANSFER_CLASS || ENABLE_SDIO_CLASS
 typedef SdSpiCard BlockDriver;
 #endif  // ENABLE_EXTENDED_TRANSFER_CLASS || ENABLE_SDIO_CLASS
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif
+
 #endif  // BlockDriver_h

--- a/src/FatLib/ArduinoFiles.h
+++ b/src/FatLib/ArduinoFiles.h
@@ -32,6 +32,11 @@
 #if ENABLE_ARDUINO_FEATURES
 #include "FatFile.h"
 #include <limits.h>
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 //------------------------------------------------------------------------------
 /** Arduino SD.h style flag for open for read. */
 #define FILE_READ O_READ
@@ -246,4 +251,9 @@ class File : public FatFile, public Stream {
   }
 };
 #endif  // ENABLE_ARDUINO_FEATURES
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif
+
 #endif  // ArduinoFiles_h

--- a/src/FatLib/ArduinoStream.h
+++ b/src/FatLib/ArduinoStream.h
@@ -31,6 +31,11 @@
 #include "FatLibConfig.h"
 #if ENABLE_ARDUINO_FEATURES
 #include "bufstream.h"
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 //==============================================================================
 /**
  * \class ArduinoInStream
@@ -150,4 +155,9 @@ class ArduinoOutStream : public ostream {
   Print* m_pr;
 };
 #endif  // ENABLE_ARDUINO_FEATURES
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif
+
 #endif  // ArduinoStream_h

--- a/src/FatLib/BaseBlockDriver.h
+++ b/src/FatLib/BaseBlockDriver.h
@@ -25,6 +25,11 @@
 #ifndef BaseBlockDriver_h
 #define BaseBlockDriver_h
 #include "FatLibConfig.h"
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 /**
  * \class BaseBlockDriver
  * \brief Base block driver.
@@ -77,4 +82,9 @@ class BaseBlockDriver {
   virtual bool writeBlocks(uint32_t block, const uint8_t* src, size_t nb) = 0;
 #endif  // USE_MULTI_BLOCK_IO
 };
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif
+
 #endif  // BaseBlockDriver_h

--- a/src/FatLib/FatApiConstants.h
+++ b/src/FatLib/FatApiConstants.h
@@ -24,6 +24,11 @@
  */
 #ifndef FatApiConstants_h
 #define FatApiConstants_h
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 // Temp fix for particle mesh.
 #ifdef O_RDONLY
 #undef O_RDONLY
@@ -79,4 +84,9 @@ const uint8_t T_ACCESS = 1;
 const uint8_t T_CREATE = 2;
 /** Set the file's write date and time */
 const uint8_t T_WRITE = 4;
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif
+
 #endif  // FatApiConstants_h

--- a/src/FatLib/FatFile.cpp
+++ b/src/FatLib/FatFile.cpp
@@ -24,6 +24,11 @@
  */
 #include "FatFile.h"
 #include "FatFileSystem.h"
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 //------------------------------------------------------------------------------
 // Pointer to cwd directory.
 FatFile* FatFile::m_cwd = 0;
@@ -1496,3 +1501,7 @@ fail:
   m_error |= WRITE_ERROR;
   return -1;
 }
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif

--- a/src/FatLib/FatFile.h
+++ b/src/FatLib/FatFile.h
@@ -36,6 +36,11 @@
 #include "FatApiConstants.h"
 #include "FatStructs.h"
 #include "FatVolume.h"
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 class FatFileSystem;
 //------------------------------------------------------------------------------
 // Stuff to store strings in AVR flash.
@@ -1003,4 +1008,9 @@ class FatFile {
   uint32_t   m_fileSize;         // file size in bytes
   uint32_t   m_firstCluster;     // first cluster of file
 };
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif
+
 #endif  // FatFile_h

--- a/src/FatLib/FatFileLFN.cpp
+++ b/src/FatLib/FatFileLFN.cpp
@@ -23,6 +23,11 @@
  * DEALINGS IN THE SOFTWARE.
  */
 #include "FatFile.h"
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 //------------------------------------------------------------------------------
 //
 uint8_t FatFile::lfnChecksum(uint8_t* name) {
@@ -686,3 +691,7 @@ done:
   return true;
 }
 #endif  // #if USE_LONG_FILE_NAMES
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif

--- a/src/FatLib/FatFilePrint.cpp
+++ b/src/FatLib/FatFilePrint.cpp
@@ -25,6 +25,11 @@
 #include <math.h>
 #include "FatFile.h"
 #include "FmtNumber.h"
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 //------------------------------------------------------------------------------
 // print uint8_t with width 2
 static void print2u(print_t* pr, uint8_t v) {
@@ -250,3 +255,7 @@ size_t FatFile::printFileSize(print_t* pr) {
   }
   return pr->write(buf);
 }
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif

--- a/src/FatLib/FatFileSFN.cpp
+++ b/src/FatLib/FatFileSFN.cpp
@@ -24,6 +24,11 @@
  */
 #include "FatFile.h"
 #include "FatFileSystem.h"
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 //------------------------------------------------------------------------------
 bool FatFile::getSFN(char* name) {
   dir_t* dir;
@@ -276,3 +281,7 @@ fail:
   return false;
 }
 #endif  // !USE_LONG_FILE_NAMES
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif

--- a/src/FatLib/FatFileSystem.h
+++ b/src/FatLib/FatFileSystem.h
@@ -27,6 +27,11 @@
 #include "FatVolume.h"
 #include "FatFile.h"
 #include "ArduinoFiles.h"
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 /**
  * \file
  * \brief FatFileSystem class
@@ -322,4 +327,9 @@ fail:
  private:
   FatFile m_vwd;
 };
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif
+
 #endif  // FatFileSystem_h

--- a/src/FatLib/FatStructs.h
+++ b/src/FatLib/FatStructs.h
@@ -24,6 +24,11 @@
  */
 #ifndef FatStructs_h
 #define FatStructs_h
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 /**
  * \file
  * \brief FAT file structures
@@ -879,4 +884,9 @@ typedef struct longDirectoryEntry ldir_t;
  * begin with an entry having this mask.
  */
 const uint8_t LDIR_ORD_LAST_LONG_ENTRY = 0X40;
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif
+
 #endif  // FatStructs_h

--- a/src/FatLib/FatVolume.cpp
+++ b/src/FatLib/FatVolume.cpp
@@ -24,6 +24,11 @@
  */
 #include <string.h>
 #include "FatVolume.h"
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 //------------------------------------------------------------------------------
 cache_t* FatCache::read(uint32_t lbn, uint8_t option) {
   if (m_lbn != lbn) {
@@ -612,3 +617,7 @@ fail:
   m_fatType = 0;
   return false;
 }
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif

--- a/src/FatLib/FatVolume.h
+++ b/src/FatLib/FatVolume.h
@@ -32,6 +32,11 @@
 #include "FatLibConfig.h"
 #include "FatStructs.h"
 #include "BlockDriver.h"
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 //------------------------------------------------------------------------------
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 /** Macro for debug. */
@@ -372,4 +377,9 @@ class FatVolume {
     return cluster > m_lastCluster;
   }
 };
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif
+
 #endif  // FatVolume

--- a/src/FatLib/FmtNumber.cpp
+++ b/src/FatLib/FmtNumber.cpp
@@ -28,6 +28,11 @@
 #include <avr/pgmspace.h>
 #define USE_STIMMER
 #endif  // __AVR__
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 //------------------------------------------------------------------------------
 // Stimmer div/mod 10 for AVR
 // this code fragment works out i/10 and i%10 by calculating
@@ -457,4 +462,6 @@ fail:
   return 0;
 }
 
-
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif

--- a/src/FatLib/FmtNumber.h
+++ b/src/FatLib/FmtNumber.h
@@ -24,15 +24,22 @@
  */
 #ifndef FmtNumber_h
 #define FmtNumber_h
+#include <math.h>
+#include <stdint.h>
+
 //  #include <ctype.h>
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 inline bool isDigit(char c) {
   return '0' <= c && c <= '9';
 }
 inline bool isSpace(char c) {
   return c == ' ' || (0X9 <= c && c <= 0XD);
 }
-#include <math.h>
-#include <stdint.h>
+
 char* fmtDec(uint16_t n, char* p);
 char* fmtDec(uint32_t n, char* p);
 char* fmtFloat(float value, char* p, uint8_t prec);
@@ -40,4 +47,9 @@ char* fmtFloat(float value, char* ptr, uint8_t prec, char expChar);
 char* fmtHex(uint32_t n, char* p);
 float scale10(float v, int8_t n);
 float scanFloat(const char* str, char** ptr);
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif
+
 #endif  // FmtNumber_h

--- a/src/FatLib/StdioStream.cpp
+++ b/src/FatLib/StdioStream.cpp
@@ -24,6 +24,11 @@
  */
 #include "StdioStream.h"
 #include "FmtNumber.h"
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 //------------------------------------------------------------------------------
 int StdioStream::fclose() {
   int rtn = 0;
@@ -525,3 +530,6 @@ char* StdioStream::fmtSpace(uint8_t len) {
   return reinterpret_cast<char*>(m_p);
 }
 
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif

--- a/src/FatLib/StdioStream.h
+++ b/src/FatLib/StdioStream.h
@@ -30,6 +30,11 @@
  */
 #include <limits.h>
 #include "FatFile.h"
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 //------------------------------------------------------------------------------
 /** Total size of stream buffer. The entire buffer is used for output.
   * During input UNGETC_BUF_SIZE of this space is reserved for ungetc.
@@ -37,6 +42,11 @@
 const uint8_t STREAM_BUF_SIZE = 64;
 /** Amount of buffer allocated for ungetc during input. */
 const uint8_t UNGETC_BUF_SIZE = 2;
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif
+
 //------------------------------------------------------------------------------
 // Get rid of any macros defined in <stdio.h>.
 #include <stdio.h>
@@ -103,6 +113,11 @@ const uint8_t UNGETC_BUF_SIZE = 2;
 /** Seek relative to start-of-file. */
 #define SEEK_SET 0
 #endif  // SEEK_SET
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 //------------------------------------------------------------------------------
 /** \class StdioStream
  * \brief StdioStream implements a minimal stdio stream.
@@ -663,5 +678,10 @@ class StdioStream : private FatFile {
   uint8_t  m_w;
   uint8_t  m_buf[STREAM_BUF_SIZE];
 };
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif
+
 //------------------------------------------------------------------------------
 #endif  // StdioStream_h

--- a/src/FatLib/bufstream.h
+++ b/src/FatLib/bufstream.h
@@ -30,6 +30,11 @@
  */
 #include <string.h>
 #include "iostream.h"
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 //==============================================================================
 /**
  * \class ibufstream
@@ -169,4 +174,9 @@ class obufstream : public ostream {
   size_t m_size;
   size_t m_in;
 };
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif
+
 #endif  // bufstream_h

--- a/src/FatLib/fstream.cpp
+++ b/src/FatLib/fstream.cpp
@@ -23,6 +23,11 @@
  * DEALINGS IN THE SOFTWARE.
  */
 #include "fstream.h"
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 //==============================================================================
 /// @cond SHOW_PROTECTED
 int16_t FatStreamBase::getch() {
@@ -170,3 +175,7 @@ void FatStreamBase::write(char c) {
   write(&c, 1);
 }
 /// @endcond
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif

--- a/src/FatLib/fstream.h
+++ b/src/FatLib/fstream.h
@@ -30,6 +30,11 @@
  */
 #include "FatFile.h"
 #include "iostream.h"
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 //==============================================================================
 /**
  * \class FatStreamBase
@@ -316,5 +321,10 @@ class ofstream : public ostream, FatStreamBase {
   }
   /// @endcond
 };
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif
+
 //------------------------------------------------------------------------------
 #endif  // fstream_h

--- a/src/FatLib/ios.h
+++ b/src/FatLib/ios.h
@@ -25,6 +25,11 @@
 #ifndef ios_h
 #define ios_h
 #include "FatFile.h"
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 /**
  * \file
  * \brief \ref ios_base and \ref ios classes
@@ -420,4 +425,9 @@ class ios : public ios_base {
  private:
   iostate m_iostate;
 };
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif
+
 #endif  // ios_h

--- a/src/FatLib/iostream.h
+++ b/src/FatLib/iostream.h
@@ -30,6 +30,11 @@
  */
 #include "istream.h"
 #include "ostream.h"
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 /** Skip white space
  * \param[in] is the Stream
  * \return The stream
@@ -155,4 +160,9 @@ inline istream &operator>>(istream &is, const setw &arg) {
  */
 class iostream : public istream, public ostream {
 };
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif
+
 #endif  // iostream_h

--- a/src/FatLib/istream.cpp
+++ b/src/FatLib/istream.cpp
@@ -26,6 +26,11 @@
 #include <float.h>
 #include <ctype.h>
 #include "istream.h"
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 //------------------------------------------------------------------------------
 int istream::get() {
   int c;
@@ -394,3 +399,7 @@ void istream::skipWhite() {
   } while (isspace(c));
   setpos(&pos);
 }
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif

--- a/src/FatLib/istream.h
+++ b/src/FatLib/istream.h
@@ -30,6 +30,10 @@
  */
 #include "ios.h"
 
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 /**
  * \class istream
  * \brief Input Stream
@@ -381,4 +385,9 @@ void istream::getNumber(T* value) {
     }
   }
 }
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif
+
 #endif  // istream_h

--- a/src/FatLib/ostream.cpp
+++ b/src/FatLib/ostream.cpp
@@ -27,6 +27,11 @@
 #ifndef PSTR
 #define PSTR(x) x
 #endif
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 //------------------------------------------------------------------------------
 void ostream::do_fill(unsigned len) {
   for (; len < width(); len++) {
@@ -194,3 +199,7 @@ void ostream::putStr(const char *str) {
   putstr(str);
   do_fill(n);
 }
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif

--- a/src/FatLib/ostream.h
+++ b/src/FatLib/ostream.h
@@ -29,6 +29,11 @@
  * \brief \ref ostream class
  */
 #include "ios.h"
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 //==============================================================================
 /**
  * \class ostream
@@ -273,4 +278,9 @@ class ostream : public virtual ios {
   void putPgm(const char* str);
   void putStr(const char* str);
 };
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif
+
 #endif  // ostream_h

--- a/src/FreeStack.h
+++ b/src/FreeStack.h
@@ -24,6 +24,11 @@
  */
 #ifndef FreeStack_h
 #define FreeStack_h
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 /**
  * \file
  * \brief FreeStack() function.
@@ -58,4 +63,9 @@ static int FreeStack() {
   return 0;
 }
 #endif
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif
+
 #endif  // FreeStack_h

--- a/src/MinimumSerial.cpp
+++ b/src/MinimumSerial.cpp
@@ -25,6 +25,11 @@
 #include "SysCall.h"
 #if defined(UDR0) || defined(DOXYGEN)
 #include "MinimumSerial.h"
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 const uint16_t MIN_2X_BAUD = F_CPU/(4*(2*0XFFF + 1)) + 1;
 //------------------------------------------------------------------------------
 int MinimumSerial::available() {
@@ -68,4 +73,9 @@ size_t MinimumSerial::write(uint8_t b) {
   UDR0 = b;
   return 1;
 }
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif
+
 #endif  //  defined(UDR0) || defined(DOXYGEN)

--- a/src/MinimumSerial.h
+++ b/src/MinimumSerial.h
@@ -29,6 +29,11 @@
 #ifndef MinimumSerial_h
 #define MinimumSerial_h
 #include "SysCall.h"
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 //==============================================================================
 /**
  * \class MinimumSerial
@@ -64,4 +69,9 @@ class MinimumSerial : public Print {
   size_t write(uint8_t b);
   using Print::write;
 };
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif
+
 #endif  // MinimumSerial_h

--- a/src/SdCard/SdInfo.h
+++ b/src/SdCard/SdInfo.h
@@ -25,6 +25,11 @@
 #ifndef SdInfo_h
 #define SdInfo_h
 #include <stdint.h>
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 // Based on the document:
 //
 // SD Specifications
@@ -477,4 +482,9 @@ inline uint32_t sdCardCapacity(csd_t* csd) {
     return 0;
   }
 }
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif
+
 #endif  // SdInfo_h

--- a/src/SdCard/SdSpiCard.cpp
+++ b/src/SdCard/SdSpiCard.cpp
@@ -23,6 +23,11 @@
  * DEALINGS IN THE SOFTWARE.
  */
 #include "SdSpiCard.h"
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 // debug trace macro
 #define SD_TRACE(m, b)
 // #define SD_TRACE(m, b) Serial.print(m);Serial.println(b);
@@ -668,3 +673,7 @@ fail:
   spiStop();
   return false;
 }
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif

--- a/src/SdCard/SdSpiCard.h
+++ b/src/SdCard/SdSpiCard.h
@@ -33,6 +33,11 @@
 #include "SdInfo.h"
 #include "../FatLib/BaseBlockDriver.h"
 #include "../SpiDriver/SdSpiDriver.h"
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 //==============================================================================
 /**
  * \class SdSpiCard
@@ -370,4 +375,9 @@ class SdSpiCardEX : public SdSpiCard {
   uint32_t m_curBlock;
   uint8_t m_curState;
 };
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif
+
 #endif  // SdSpiCard_h

--- a/src/SdCard/SdSpiCardEX.cpp
+++ b/src/SdCard/SdSpiCardEX.cpp
@@ -23,6 +23,11 @@
  * DEALINGS IN THE SOFTWARE.
  */
 #include "SdSpiCard.h"
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 bool SdSpiCardEX::readBlock(uint32_t block, uint8_t* dst) {
   if (m_curState != READ_STATE || block != m_curBlock) {
     if (!syncBlocks()) {
@@ -92,3 +97,7 @@ bool SdSpiCardEX::writeBlocks(uint32_t block,
   }
   return true;
 }
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif

--- a/src/SdCard/SdioCard.h
+++ b/src/SdCard/SdioCard.h
@@ -26,6 +26,11 @@
 #define SdioCard_h
 #include "SysCall.h"
 #include "BlockDriver.h"
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 /**
  * \class SdioCard
  * \brief Raw SDIO access to SD and SDHC flash memory cards.
@@ -298,4 +303,9 @@ class SdioCardEX : public SdioCard {
   uint32_t m_limitLba;
   uint8_t m_curState;
 };
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif
+
 #endif  // SdioCard_h

--- a/src/SdCard/SdioCardEX.cpp
+++ b/src/SdCard/SdioCardEX.cpp
@@ -24,6 +24,10 @@
  */
 #include "SdioCard.h"
 
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 // limit of K66 due to errata KINETIS_K_0N65N.
 const uint32_t MAX_SDHC_COUNT = 0XFFFF;
 
@@ -106,3 +110,7 @@ bool SdioCardEX::writeBlocks(uint32_t lba, const uint8_t* src, size_t nb) {
   }
   return true;
 }
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif

--- a/src/SdCard/SdioTeensy.cpp
+++ b/src/SdCard/SdioTeensy.cpp
@@ -24,6 +24,11 @@
  */
 #if defined(__MK64FX512__) || defined(__MK66FX1M0__)
 #include "SdioCard.h"
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 //==============================================================================
 #define SDHC_PROCTL_DTW_4BIT 0x01
 const uint32_t FIFO_WML = 16;
@@ -797,4 +802,9 @@ bool SdioCard::writeStart(uint32_t lba, uint32_t count) {
 bool SdioCard::writeStop() {
   return transferStop();
 }
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif
+
 #endif  // defined(__MK64FX512__) || defined(__MK66FX1M0__)

--- a/src/SdFat.h
+++ b/src/SdFat.h
@@ -35,6 +35,11 @@
 #if INCLUDE_SDIOS
 #include "sdios.h"
 #endif  // INCLUDE_SDIOS
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 //------------------------------------------------------------------------------
 /** SdFat version */
 #define SD_FAT_VERSION "1.0.8"
@@ -509,4 +514,9 @@ class Sd2Card : public SdSpiCard {
  private:
   SdFatSpiDriver m_spi;
 };
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif
+
 #endif  // SdFat_h

--- a/src/SpiDriver/DigitalPin.h
+++ b/src/SpiDriver/DigitalPin.h
@@ -32,8 +32,16 @@
  */
 #ifndef DigitalPin_h
 #define DigitalPin_h
+
 #if defined(__AVR__) || defined(DOXYGEN)
 #include <avr/io.h>
+#endif
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
+#if defined(__AVR__) || defined(DOXYGEN)
 /** GpioPinMap type */
 struct GpioPinMap_t {
   volatile uint8_t* pin;   /**< address of PIN for this pin */
@@ -298,6 +306,7 @@ inline void fastPinMode(uint8_t pin, uint8_t mode) {
  * @class DigitalPin
  * @brief Fast digital port I/O
  */
+
 template<uint8_t PinNumber>
 class DigitalPin {
  public:
@@ -382,5 +391,10 @@ class DigitalPin {
     fastDigitalWrite(PinNumber, value);
   }
 };
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif
+
 #endif  // DigitalPin_h
 /** @} */

--- a/src/SpiDriver/SdSpiBaseDriver.h
+++ b/src/SpiDriver/SdSpiBaseDriver.h
@@ -24,6 +24,11 @@
  */
 #ifndef SdSpiBaseDriver_h
 #define SdSpiBaseDriver_h
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 /**
  * \class SdSpiBaseDriver
  * \brief SPI base driver.
@@ -76,4 +81,9 @@ class SdSpiBaseDriver {
   /** Set CS high. */
   virtual void unselect() = 0;
 };
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif
+
 #endif  // SdSpiBaseDriver_h

--- a/src/SpiDriver/SdSpiDriver.h
+++ b/src/SpiDriver/SdSpiDriver.h
@@ -37,6 +37,11 @@
 #ifndef SDCARD_SPI
 #define SDCARD_SPI SPI
 #endif  // SDCARD_SPI
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 //-----------------------------------------------------------------------------
 /**
  * \class SdSpiLibDriver
@@ -196,6 +201,11 @@ class SdSpiAltDriver {
   SPISettings m_spiSettings;
   uint8_t m_csPin;
 };
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif
+
 //------------------------------------------------------------------------------
 #if ENABLE_SOFTWARE_SPI_CLASS || defined(DOXYGEN)
 #ifdef ARDUINO
@@ -203,6 +213,11 @@ class SdSpiAltDriver {
 #elif defined(PLATFORM_ID)  // Only defined if a Particle device
 #include "SoftSPIParticle.h"
 #endif  // ARDUINO
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 /**
  * \class SdSpiSoftDriver
  * \brief Software SPI class for access to SD and SDHC flash memory cards.
@@ -281,7 +296,17 @@ class SdSpiSoftDriver : public SdSpiBaseDriver {
   uint8_t m_csPin;
   SoftSPI<MisoPin, MosiPin, SckPin, 0> m_spi;
 };
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif
+
 #endif  // ENABLE_SOFTWARE_SPI_CLASS || defined(DOXYGEN)
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 //-----------------------------------------------------------------------------
 // Choose SPI driver for SdFat and SdFatEX classes.
 #if USE_STANDARD_SPI_LIBRARY || !SD_HAS_CUSTOM_SPI
@@ -366,4 +391,9 @@ inline void SdSpiAltDriver::send(const uint8_t* buf , size_t n) {
   while (!(SPSR & (1 << SPIF))) {}
 }
 #endif  // __AVR__
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif
+
 #endif  // SdSpiDriver_h

--- a/src/SpiDriver/SdSpiESP8266.cpp
+++ b/src/SpiDriver/SdSpiESP8266.cpp
@@ -24,6 +24,11 @@
  */
 #if defined(ESP8266)
 #include "SdSpiDriver.h"
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 //------------------------------------------------------------------------------
 /** Initialize the SPI bus.
  *
@@ -90,4 +95,9 @@ void SdSpiAltDriver::send(const uint8_t* buf , size_t n) {
   }
   SPI.transferBytes(const_cast<uint8_t*>(buf), 0, n);
 }
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif
+
 #endif  // defined(ESP8266)

--- a/src/SpiDriver/SdSpiSAM3X.cpp
+++ b/src/SpiDriver/SdSpiSAM3X.cpp
@@ -40,6 +40,11 @@
 #define SPI_TX_IDX  1
 /** DMAC Channel HW Interface Number for SPI RX. */
 #define SPI_RX_IDX  2
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 //------------------------------------------------------------------------------
 /** Disable DMA Controller. */
 static void dmac_disable() {
@@ -215,4 +220,9 @@ void SdSpiAltDriver::send(const uint8_t* buf , size_t n) {
   // leave RDR empty
   uint8_t b = pSpi->SPI_RDR;
 }
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif
+
 #endif  // defined(__SAM3X8E__) || defined(__SAM3X8H__)

--- a/src/SpiDriver/SdSpiSTM32.cpp
+++ b/src/SpiDriver/SdSpiSTM32.cpp
@@ -31,6 +31,11 @@
 #else  // defined(__STM32F1__)
 #error Unknown STM32 type
 #endif  // defined(__STM32F1__)
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 //------------------------------------------------------------------------------
 static SPIClass m_SPI1(1);
 #if BOARD_NR_SPI >= 2
@@ -127,4 +132,9 @@ void SdSpiAltDriver::setPort(uint8_t portNumber) {
   }
 #endif  // BOARD_NR_SPI >= 2
 }
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif
+
 #endif  // defined(__STM32F1__) || defined(__STM32F4__)

--- a/src/SpiDriver/SdSpiTeensy3.cpp
+++ b/src/SpiDriver/SdSpiTeensy3.cpp
@@ -27,6 +27,10 @@
 // SPI definitions
 #include "kinetis.h"
 
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 //------------------------------------------------------------------------------
 void SdSpiAltDriver::activate() {
   SPI.beginTransaction(m_spiSettings);
@@ -230,4 +234,9 @@ void SdSpiAltDriver::send(const uint8_t* buf , size_t n) {
   }
 }
 #endif  // KINETISK
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif
+
 #endif  // defined(__arm__) && defined(CORE_TEENSY)

--- a/src/SpiDriver/SoftSPI.h
+++ b/src/SpiDriver/SoftSPI.h
@@ -46,6 +46,11 @@
 #define MOSI_MODE  OUTPUT
 /** Pin Mode for SCK is output. */
 #define SCK_MODE  OUTPUT
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 //------------------------------------------------------------------------------
 /**
  * @class SoftSPI
@@ -163,5 +168,10 @@ class SoftSPI {
   }
   //----------------------------------------------------------------------------
 };
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif
+
 #endif  // SoftSPI_h
 /** @} */

--- a/src/SpiDriver/boards/AvrDevelopersGpioPinMap.h
+++ b/src/SpiDriver/boards/AvrDevelopersGpioPinMap.h
@@ -1,5 +1,10 @@
 #ifndef AvrDevelopersGpioPinMap_h
 #define AvrDevelopersGpioPinMap_h
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 static const GpioPinMap_t GpioPinMap[] = {
   GPIO_PIN(B, 0),  // D0
   GPIO_PIN(B, 1),  // D1
@@ -34,4 +39,9 @@ static const GpioPinMap_t GpioPinMap[] = {
   GPIO_PIN(A, 1),  // D30
   GPIO_PIN(A, 0)   // D31
 };
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif
+
 #endif  // AvrDevelopersGpioPinMap_h

--- a/src/SpiDriver/boards/BobuinoGpioPinMap.h
+++ b/src/SpiDriver/boards/BobuinoGpioPinMap.h
@@ -1,5 +1,10 @@
 #ifndef BobuinoGpioPinMap_h
 #define BobuinoGpioPinMap_h
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 static const GpioPinMap_t GpioPinMap[] = {
   GPIO_PIN(B, 0),  // D0
   GPIO_PIN(B, 1),  // D1
@@ -34,4 +39,9 @@ static const GpioPinMap_t GpioPinMap[] = {
   GPIO_PIN(A, 6),  // D30
   GPIO_PIN(A, 7)   // D31
 };
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif
+
 #endif  // BobuinoGpioPinMap_h

--- a/src/SpiDriver/boards/LeonardoGpioPinMap.h
+++ b/src/SpiDriver/boards/LeonardoGpioPinMap.h
@@ -1,5 +1,10 @@
 #ifndef LeonardoGpioPinMap_h
 #define LeonardoGpioPinMap_h
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 static const GpioPinMap_t GpioPinMap[] = {
   GPIO_PIN(D, 2),  // D0
   GPIO_PIN(D, 3),  // D1
@@ -32,4 +37,9 @@ static const GpioPinMap_t GpioPinMap[] = {
   GPIO_PIN(B, 6),  // D28
   GPIO_PIN(D, 6)   // D29
 };
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif
+
 #endif  // LeonardoGpioPinMap_h

--- a/src/SpiDriver/boards/MegaGpioPinMap.h
+++ b/src/SpiDriver/boards/MegaGpioPinMap.h
@@ -1,5 +1,10 @@
 #ifndef MegaGpioPinMap_h
 #define MegaGpioPinMap_h
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 static const GpioPinMap_t GpioPinMap[] = {
   GPIO_PIN(E, 0),  // D0
   GPIO_PIN(E, 1),  // D1
@@ -72,4 +77,9 @@ static const GpioPinMap_t GpioPinMap[] = {
   GPIO_PIN(K, 6),  // D68
   GPIO_PIN(K, 7)   // D69
 };
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif
+
 #endif  // MegaGpioPinMap_h

--- a/src/SpiDriver/boards/SleepingBeautyGpioPinMap.h
+++ b/src/SpiDriver/boards/SleepingBeautyGpioPinMap.h
@@ -1,5 +1,10 @@
 #ifndef SleepingBeautyGpioPinMap_h
 #define SleepingBeautyGpioPinMap_h
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 static const GpioPinMap_t GpioPinMap[] = {
   GPIO_PIN(D, 0),  // D0
   GPIO_PIN(D, 1),  // D1
@@ -34,4 +39,9 @@ static const GpioPinMap_t GpioPinMap[] = {
   GPIO_PIN(A, 6),  // D30
   GPIO_PIN(A, 7)   // D31
 };
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif
+
 #endif  // SleepingBeautyGpioPinMap_h

--- a/src/SpiDriver/boards/Standard1284GpioPinMap.h
+++ b/src/SpiDriver/boards/Standard1284GpioPinMap.h
@@ -1,5 +1,10 @@
 #ifndef Standard1284GpioPinMap_h
 #define Standard1284GpioPinMap_h
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 static const GpioPinMap_t GpioPinMap[] = {
   GPIO_PIN(B, 0),  // D0
   GPIO_PIN(B, 1),  // D1
@@ -34,4 +39,9 @@ static const GpioPinMap_t GpioPinMap[] = {
   GPIO_PIN(A, 6),  // D30
   GPIO_PIN(A, 7)   // D31
 };
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif
+
 #endif  // Standard1284GpioPinMap_h

--- a/src/SpiDriver/boards/Teensy2GpioPinMap.h
+++ b/src/SpiDriver/boards/Teensy2GpioPinMap.h
@@ -1,5 +1,10 @@
 #ifndef Teensy2GpioPinMap_h
 #define Teensy2GpioPinMap_h
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 static const GpioPinMap_t GpioPinMap[] = {
   GPIO_PIN(B, 0),  // D0
   GPIO_PIN(B, 1),  // D1
@@ -27,4 +32,9 @@ static const GpioPinMap_t GpioPinMap[] = {
   GPIO_PIN(D, 5),  // D23
   GPIO_PIN(E, 6),  // D24
 };
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif
+
 #endif  // Teensy2GpioPinMap_h

--- a/src/SpiDriver/boards/Teensy2ppGpioPinMap.h
+++ b/src/SpiDriver/boards/Teensy2ppGpioPinMap.h
@@ -1,5 +1,10 @@
 #ifndef Teensypp2GpioPinMap_h
 #define Teensypp2GpioPinMap_h
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 static const GpioPinMap_t GpioPinMap[] = {
   GPIO_PIN(D, 0),  // D0
   GPIO_PIN(D, 1),  // D1
@@ -48,4 +53,9 @@ static const GpioPinMap_t GpioPinMap[] = {
   GPIO_PIN(F, 6),  // D44
   GPIO_PIN(F, 7),  // D45
 };
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif
+
 #endif  // Teensypp2GpioPinMap_h

--- a/src/SpiDriver/boards/UnoGpioPinMap.h
+++ b/src/SpiDriver/boards/UnoGpioPinMap.h
@@ -1,5 +1,10 @@
 #ifndef UnoGpioPinMap_h
 #define UnoGpioPinMap_h
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 static const GpioPinMap_t GpioPinMap[] = {
   GPIO_PIN(D, 0),  // D0
   GPIO_PIN(D, 1),  // D1
@@ -22,4 +27,9 @@ static const GpioPinMap_t GpioPinMap[] = {
   GPIO_PIN(C, 4),  // D18
   GPIO_PIN(C, 5)   // D19
 };
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif
+
 #endif  // UnoGpioPinMap_h

--- a/src/SysCall.h
+++ b/src/SysCall.h
@@ -24,6 +24,7 @@
  */
 #ifndef SysCall_h
 #define SysCall_h
+
 /**
  * \file
  * \brief SysCall class
@@ -36,6 +37,11 @@
 #else  // defined(ARDUINO)
 #error "Unknown system"
 #endif  // defined(ARDUINO)
+
+#ifdef SDFAT_NAMESPACE
+namespace sdfat {
+#endif
+
 //-----------------------------------------------------------------------------
 #ifdef ESP8266
 // undefine F macro if ESP8266.
@@ -85,4 +91,9 @@ inline void SysCall::yield() {
 #else  // ESP8266
 inline void SysCall::yield() {}
 #endif  // ESP8266
+
+#ifdef SDFAT_NAMESPACE
+}; // namespace sdfat
+#endif
+
 #endif  // SysCall_h


### PR DESCRIPTION
The ESP8266 (and probably others) have conflicting class names for "File"
and a few other names defined in SdFat.

To guard against this, when the symbol "SDFAT_NAMESPACE" is defined at
compile-time, bracket all objects, globals, constants, etc. in a
"namespace sdfat { ... };" block.

All examples updated to add "using namespace sdfat;" when required,
meaning that they compile and run whether or not the define is set.

No changes to existing apps are needed.