### PR TITLE
Make SPI receive buffer 32-bit aligned on 8266

### DIFF
--- a/src/SpiDriver/SdSpiESP8266.cpp
+++ b/src/SpiDriver/SdSpiESP8266.cpp
@@ -64,7 +64,12 @@ uint8_t SdSpiAltDriver::receive() {
  * \return Zero for no error or nonzero error code.
  */
 uint8_t SdSpiAltDriver::receive(uint8_t* buf, size_t n) {
-  // Works without 32-bit alignment of buf.
+  // Adjust to 32-bit alignment.
+  while ((reinterpret_cast<uintptr_t>(buf) & 0X3) && n) {
+    *buf++ = SPI.transfer(0xff);
+    n--;
+  }
+  // Buff now 32-bit aligned
   SPI.transferBytes(0, buf, n);
   return 0;
 }


### PR DESCRIPTION
The ESP8266 SPI implementation needs a 4-byte aligned read buffer,
same as for transmit.  Fix the ESP8266 SPI driver wrapper to ensure
this alignment occurs, using same method as for transmit.

Without this change, occasional LoadStoreAlignment exceptions occur
depending on the input buffer alignment.