### PR TITLE
fix pinmode error in fastPinMode for particle devices

### DIFF
--- a/src/SpiDriver/DigitalPin.h
+++ b/src/SpiDriver/DigitalPin.h
@@ -280,9 +280,8 @@ inline void fastDigitalToggle(uint8_t pin) {
   fastDigitalWrite(pin, !fastDigitalRead(pin));
 }
 //------------------------------------------------------------------------------
-inline void fastPinMode(uint8_t pin, uint8_t mode) {
-  pinMode(pin, mode);
-}
+#define fastPinMode(pin, mode)\
+  {pinMode(pin, mode);}
 #endif  // __AVR__
 //------------------------------------------------------------------------------
 /** set pin configuration


### PR DESCRIPTION
When using SoftSPI on Particle devices, the compiler throws an error in fastPinMode(...):
```
/lib/SdFat/src/SdCard/../SpiDriver/DigitalPin.h:287:20: error: invalid conversion from 'uint8_t {aka unsigned char}' to 'PinMode' [-fpermissive]
   pinMode(pin, mode);
...
../wiring/inc/spark_wiring.h:72:6: note:   initializing argument 2 of 'void pinMode(uint16_t, PinMode)'
 void pinMode(uint16_t pin, PinMode mode);
```

Suggested fix moves the call to pinMode(pin, mode) into a macro to avoid enforcing a type in the library.

I don't believe this should alter compatibility with any other devices since fastPinMode is just a passthrough function there anyways.
