### PR TITLE
Add support for Arduino Nano 33 BLE boards (Mbed Core)

### DIFF
--- a/src/FatLib/FatApiConstants.h
+++ b/src/FatLib/FatApiConstants.h
@@ -44,6 +44,18 @@
 #define O_AT_END O_NONBLOCK  ///< Open at EOF.
 typedef int oflag_t;
 #else  // USE_FCNTL_H
+#if defined(ARDUINO_ARCH_MBED)
+#undef O_RDONLY
+#undef O_WRONLY
+#undef O_RDWR
+#undef O_NONBLOCK
+#undef O_APPEND
+#undef O_CREAT
+#undef O_TRUNC
+#undef O_EXCL
+#undef O_BINARY
+#undef O_ACCMODE
+#endif
 #define O_RDONLY  0X00  ///< Open for reading only.
 #define O_WRONLY  0X01  ///< Open for writing only.
 #define O_RDWR    0X02  ///< Open for reading and writing.

--- a/src/SdFatConfig.h
+++ b/src/SdFatConfig.h
@@ -90,7 +90,7 @@
  * O_WRONLY, O_RDWR and the open modifiers O_APPEND, O_CREAT, O_EXCL, O_SYNC
  * will be defined by including the system file fcntl.h.
  */
-#if defined(__AVR__)
+#if defined(__AVR__) || defined(ARDUINO_ARCH_MBED)
 // AVR fcntl.h does not define open flags.
 #define USE_FCNTL_H 0
 #elif defined(PLATFORM_ID)


### PR DESCRIPTION
Add support for Arduino Nano 33 BLE boards based on MbedOS Core.

Mostly deals with `fnctl`-related stuff.

Tested with a few of the provided example sketches on Arduino Nano 33 BLE with Arduino MKR MEM Shield.