### PR TITLE
Changes for local relative includes to work

### DIFF
--- a/src/FatLib/FatApiConstants.h
+++ b/src/FatLib/FatApiConstants.h
@@ -24,7 +24,7 @@
  */
 #ifndef FatApiConstants_h
 #define FatApiConstants_h
-#include "SdFatConfig.h"
+#include "../SdFatConfig.h"
 
 #if USE_FCNTL_H
 #include <fcntl.h>

--- a/src/FatLib/FatLibConfig.h
+++ b/src/FatLib/FatLibConfig.h
@@ -30,7 +30,7 @@
 #define FatLibConfig_h
 #include <stdint.h>
 // Allow this file to override defaults.
-#include "SdFatConfig.h"
+#include "../SdFatConfig.h"
 
 #ifdef __AVR__
 #include <avr/io.h>

--- a/src/FatLib/FatVolume.h
+++ b/src/FatLib/FatVolume.h
@@ -31,7 +31,7 @@
 #include <stddef.h>
 #include "FatLibConfig.h"
 #include "FatStructs.h"
-#include "BlockDriver.h"
+#include "../BlockDriver.h"
 //------------------------------------------------------------------------------
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 /** Macro for debug. */

--- a/src/SdCard/SdSpiCard.h
+++ b/src/SdCard/SdSpiCard.h
@@ -29,7 +29,7 @@
  * \brief SdSpiCard class for V2 SD/SDHC cards
  */
 #include <stddef.h>
-#include "SysCall.h"
+#include "../SysCall.h"
 #include "SdInfo.h"
 #include "../FatLib/BaseBlockDriver.h"
 #include "../SpiDriver/SdSpiDriver.h"

--- a/src/SdCard/SdioCard.h
+++ b/src/SdCard/SdioCard.h
@@ -24,8 +24,8 @@
  */
 #ifndef SdioCard_h
 #define SdioCard_h
-#include "SysCall.h"
-#include "BlockDriver.h"
+#include "../SysCall.h"
+#include "../BlockDriver.h"
 /**
  * \class SdioCard
  * \brief Raw SDIO access to SD and SDHC flash memory cards.

--- a/src/SpiDriver/SdSpiDriver.h
+++ b/src/SpiDriver/SdSpiDriver.h
@@ -31,7 +31,7 @@
 #include <Arduino.h>
 #include "SPI.h"
 #include "SdSpiBaseDriver.h"
-#include "SdFatConfig.h"
+#include "../SdFatConfig.h"
 //------------------------------------------------------------------------------
 /** SDCARD_SPI is defined if board has built-in SD card socket */
 #ifndef SDCARD_SPI


### PR DESCRIPTION
Arduino allows one to have a directory structure as follows:

```
sketch/
- sketch.ino
+ src/
  + SdFat/
    - library.properties
    - LICENSE.md
    - README.md
    + src/
      - SdFat.h
      + FatLib
      ...
```

This is useful when one want to commit specific versions of libraries into git as submodules. This is also useful in cases where you do not trust what is on the system, or if you want to save the effort of installing many libraries.

To get SdFat to compile in this circumstance, I had to make a few changes to the relative includes.

References:
https://github.com/arduino/arduino-builder/pull/148
https://github.com/arduino/Arduino/issues/5186#issuecomment-236554139