### PR TITLE
Add bulk transfer support for Artemis core.

### DIFF
--- a/src/SpiDriver/SdSpiArtemis.cpp
+++ b/src/SpiDriver/SdSpiArtemis.cpp
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2011-2018 Bill Greiman
+ * This file is part of the SdFat library for SD memory cards.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#if defined(ARDUINO_ARCH_APOLLO3)
+#include "SdSpiDriver.h"
+
+//------------------------------------------------------------------------------
+/** Set SPI options for access to SD/SDHC cards.
+ *
+ * \param[in] divisor SCK clock divider relative to the APB1 or APB2 clock.
+ */
+void SdSpiAltDriver::activate()
+{
+  SDCARD_SPI.beginTransaction(m_spiSettings);
+}
+//------------------------------------------------------------------------------
+/** Initialize the SPI bus.
+ *
+ * \param[in] chipSelectPin SD card chip select pin.
+ */
+void SdSpiAltDriver::begin(uint8_t csPin)
+{
+  m_csPin = csPin;
+  SDCARD_SPI.begin();
+  pinMode(m_csPin, OUTPUT);
+  digitalWrite(m_csPin, HIGH);
+}
+//------------------------------------------------------------------------------
+/**
+ * End SPI transaction.
+ */
+void SdSpiAltDriver::deactivate()
+{
+  SDCARD_SPI.endTransaction();
+}
+//------------------------------------------------------------------------------
+/** Receive a byte.
+ *
+ * \return The byte.
+ */
+uint8_t SdSpiAltDriver::receive()
+{
+  return SDCARD_SPI.transfer(0XFF);
+}
+//------------------------------------------------------------------------------
+/** Receive multiple bytes.
+ *
+ * \param[out] buf Buffer to receive the data.
+ * \param[in] n Number of bytes to receive.
+ *
+ * \return Zero for no error or nonzero error code.
+ */
+uint8_t SdSpiAltDriver::receive(uint8_t *buf, size_t n)
+{
+  SDCARD_SPI.transferIn(buf, n);
+  return 0;
+}
+//------------------------------------------------------------------------------
+/** Send a byte.
+ *
+ * \param[in] b Byte to send
+ */
+void SdSpiAltDriver::send(uint8_t b)
+{
+  SDCARD_SPI.transfer(b);
+}
+//------------------------------------------------------------------------------
+/** Send multiple bytes.
+ *
+ * \param[in] buf Buffer for data to be sent.
+ * \param[in] n Number of bytes to send.
+ */
+void SdSpiAltDriver::send(const uint8_t *buf, size_t n)
+{
+  //Convert byte array to 4 byte array
+  uint32_t myArray[n / 4];
+  for (int x = 0; x < n / 4; x++)
+  {
+    myArray[x] = ((uint32_t)buf[(x * 4) + 3] << (8 * 3)) |
+                 ((uint32_t)buf[(x * 4) + 2] << (8 * 2)) |
+                 ((uint32_t)buf[(x * 4) + 1] << (8 * 1)) |
+                 ((uint32_t)buf[(x * 4) + 0] << (8 * 0));
+  }
+  SDCARD_SPI.transfer((void *)myArray, n);
+}
+#endif // defined(ARDUINO_ARCH_APOLLO3)


### PR DESCRIPTION
Hi Bill - Are you accepting support for new platforms? I have added support for our Artemis platform with this PR.

The Artemis is based on the Apollo3. This is a Cortex-M4F that runs at 48MHz. This PR creates the SdSpiArtemis.cpp that hooks in via the ARDUINO_ARCH_APOLLO3 flag set during compile time.

Tested examples:

* ReadWrite
* bench
* DirectoryFunctions
* LongFileName

This PR achieved decent benchmarks:
write: 286 / 289 kb/s
read: 958 / 958 kb/s

There are probably plenty of issues with this PR so please feel free to educate me.

Testing was done on a [RedBoard ATP](https://www.sparkfun.com/products/15442) with [microSD breakout](https://www.sparkfun.com/products/544) with jumper wires at 48MHz (works great!). If you need any hardware for testing, please let me know.

Note that if you do your own testing you will need to use [this branch](https://github.com/sparkfun/Arduino_Apollo3/tree/betterSPI) that fixes a bug that allows our SPI clock to go above 48MHz (the examples were pushing the Apollo3 SPI clock to 50MHz). The branch will be merged in a few days.

Cheers,
-Nathan