### PR TITLE
Prevent HardFault if CWD is uninitialized

### DIFF
--- a/src/FatLib/FatFile.cpp
+++ b/src/FatLib/FatFile.cpp
@@ -262,7 +262,7 @@ bool FatFile::mkdir(FatFile* parent, const char* path, bool pFlag) {
   fname_t fname;
   FatFile tmpDir;
 
-  if (isOpen() || !parent->isDir()) {
+  if (!parent || isOpen() || !parent->isDir()) {
     DBG_FAIL_MACRO;
     goto fail;
   }
@@ -379,7 +379,7 @@ bool FatFile::open(FatFile* dirFile, const char* path, oflag_t oflag) {
   fname_t fname;
 
   // error if already open
-  if (isOpen() || !dirFile->isDir()) {
+  if (!dirFile || isOpen() || !dirFile->isDir()) {
     DBG_FAIL_MACRO;
     goto fail;
   }
@@ -425,7 +425,7 @@ bool FatFile::open(FatFile* dirFile, uint16_t index, oflag_t oflag) {
   ldir_t*ldir;
 
   // Error if already open.
-  if (isOpen() || !dirFile->isDir()) {
+  if (!dirFile || isOpen() || !dirFile->isDir()) {
     DBG_FAIL_MACRO;
     goto fail;
   }
@@ -582,7 +582,7 @@ bool FatFile::openNext(FatFile* dirFile, oflag_t oflag) {
   uint16_t index;
 
   // Check for not open and valid directory..
-  if (isOpen() || !dirFile->isDir() || (dirFile->curPosition() & 0X1F)) {
+  if (!dirFile || isOpen() || !dirFile->isDir() || (dirFile->curPosition() & 0X1F)) {
     DBG_FAIL_MACRO;
     goto fail;
   }
@@ -643,7 +643,7 @@ bool FatFile::openParent(FatFile* dirFile) {
   uint32_t ddc;
   cache_t* cb;
 
-  if (isOpen() || !dirFile->isOpen()) {
+  if (!dirFile || isOpen() || !dirFile->isOpen()) {
     goto fail;
   }
   if (dirFile->m_dirCluster == 0) {

--- a/src/FatLib/FatFile.h
+++ b/src/FatLib/FatFile.h
@@ -571,6 +571,10 @@ class FatFile {
    * the value false is returned for failure.
    */
   bool open(const char* path, oflag_t oflag = O_RDONLY) {
+    if (!m_cwd) {
+      DBG_FAIL_MACRO;
+      return false;
+    }
     return open(m_cwd, path, oflag);
   }
   /** Open current working directory.

--- a/src/FatLib/FatFileLFN.cpp
+++ b/src/FatLib/FatFileLFN.cpp
@@ -303,7 +303,7 @@ bool FatFile::open(FatFile* dirFile, fname_t* fname, oflag_t oflag) {
   ldir_t* ldir;
   size_t len = fname->len;
 
-  if (!dirFile->isDir() || isOpen()) {
+  if (!dirFile || !dirFile->isDir() || isOpen()) {
     DBG_FAIL_MACRO;
     goto fail;
   }


### PR DESCRIPTION
This PR adds a few pointer checks to prevent a HardFault from occurring when using `FatFile::open(const char* path, oflag_t oflag)` without correctly initializing the SD card first.