### PR TITLE
Allow USE_STANDARD_SPI_LIBRARY to be defined pre build

### DIFF
--- a/src/SdFatConfig.h
+++ b/src/SdFatConfig.h
@@ -77,7 +77,9 @@
  * USE_STANDARD_SPI_LIBRARY is two, the SPI port can be selected with the
  * constructors SdFat(SPIClass* spiPort) and SdFatEX(SPIClass* spiPort).
  */
-#define USE_STANDARD_SPI_LIBRARY 0
+#ifndef USE_STANDARD_SPI_LIBRARY
+  #define USE_STANDARD_SPI_LIBRARY 0
+#endif
 //------------------------------------------------------------------------------
 /**
  * If the symbol ENABLE_SOFTWARE_SPI_CLASS is nonzero, the class SdFatSoftSpi


### PR DESCRIPTION
Allow USE_STANDARD_SPI_LIBRARY to be redefined elsewhere first, this allows Platformio to set a the build flag first.
This massively helps using the library on boards that have the SPI port on different pins etc...

Currently, have to modify the file everytime I download it.

Example Usage:

build_flags =
  -DUSE_STANDARD_SPI_LIBRARY=2

OR

#define USE_STANDARD_SPI_LIBRARY 2
#include "SdFat.h"

Prevents the following error: ```no matching function for call to 'SdFat::SdFat(SPIClass*)'```
 When using a reference to the SPI class ```SdFat sdCard((SPIClass*)&SPI_SD_ETH);```