### PR TITLE
Don't call Particle.process() if system threading is enabled

### DIFF
--- a/src/common/SysCall.h
+++ b/src/common/SysCall.h
@@ -79,7 +79,10 @@ inline SdMillis_t SysCall::curTimeMS() {
 //------------------------------------------------------------------------------
 #if defined(PLATFORM_ID)  // Only defined if a Particle device
 inline void SysCall::yield() {
-  Particle.process();
+  // Recommended to only call Particle.process() if system threading is disabled
+  if (system_thread_get_state(NULL) == spark::feature::DISABLED) {
+    Particle.process();
+  }
 }
 #elif defined(ARDUINO)
 inline void SysCall::yield() {


### PR DESCRIPTION
I really appreciate the work you have done on this library.  I had an opportunity to speak with a developer at Particle and he recommended to not call Particle.process() if system threading is enabled.  It's a minor change but I wanted to make at least a small contribution to the library.