### PR TITLE
Fix uninitialized variable in FatFile::parsePathName

### DIFF
--- a/src/FatLib/FatFileLFN.cpp
+++ b/src/FatLib/FatFileLFN.cpp
@@ -476,6 +476,7 @@ bool FatFile::parsePathName(const char* path,
     path++;
   }
   fname->begin = path;
+  fname->len =0;
   while (*path && !isDirSeparator(*path)) {
 #if USE_UTF8_LONG_NAMES
     uint32_t cp;


### PR DESCRIPTION
In an error case, it is possible that `fname->len` is not initted in the
FatFile::parsePathName function.  That length variable is later used
to determine if the name was not set or was too long in line 508,
resulting in undefined behavior.  Fix by clearing on entry.

Detected by `valgrind` run in the ESP8266 repo:
````
2021-11-03T08:00:01.6217614Z ==7070== Conditional jump or move depends on uninitialised value(s)
2021-11-03T08:00:01.6220064Z ==7070==    at 0x3150FD: FatFile::parsePathName(char const*, FatLfn_t*, char const**) (FatFileLFN.cpp:507)
2021-11-03T08:00:01.6222013Z ==7070==    by 0x3107A9: FatFile::open(FatFile*, char const*, unsigned char) (FatFile.cpp:448)
2021-11-03T08:00:01.6223860Z ==7070==    by 0x310638: FatFile::open(FatVolume*, char const*, unsigned char) (FatFile.cpp:422)
2021-11-03T08:00:01.6225630Z ==7070==    by 0x2F5187: FatVolume::exists(char const*) (FatVolume.h:86)
2021-11-03T08:00:01.6227292Z ==7070==    by 0x2F572A: sdfs::SDFSImpl::exists(char const*) (SDFS.h:85)
2021-11-03T08:00:01.6228874Z ==7070==    by 0x2D32F2: fs::FS::exists(char const*) (FS.cpp:379)
2021-11-03T08:00:01.6230462Z ==7070==    by 0x192CFD: sdfs_test::____C_A_T_C_H____T_E_S_T____110() (test_fs.inc:119)
2021-11-03T08:00:01.6232199Z ==7070==    by 0x24F4BC: Catch::FreeFunctionTestCase::invoke() const (catch.hpp:5874)
2021-11-03T08:00:01.6233964Z ==7070==    by 0x220F53: Catch::TestCase::invoke() const (catch.hpp:6779)
2021-11-03T08:00:01.6235739Z ==7070==    by 0x24A24F: Catch::RunContext::invokeActiveTestCase() (catch.hpp:5473)
2021-11-03T08:00:01.6238099Z ==7070==    by 0x249A8D: Catch::RunContext::runCurrentTest(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&) (catch.hpp:5445)
2021-11-03T08:00:01.6240343Z ==7070==    by 0x246DCB: Catch::RunContext::runTest(Catch::TestCase const&) (catch.hpp:5284)
2021-11-03T08:00:01.6242064Z ==7070==  Uninitialised value was created by a stack allocation
2021-11-03T08:00:01.6244345Z ==7070==    at 0x310664: FatFile::open(FatFile*, char const*, unsigned char) (FatFile.cpp:425)
2021-11-03T08:00:01.6246169Z ==7070== 
2021-11-03T08:00:01.6251775Z ==7070== Conditional jump or move depends on uninitialised value(s)
2021-11-03T08:00:01.6254096Z ==7070==    at 0x31510D: FatFile::parsePathName(char const*, FatLfn_t*, char const**) (FatFileLFN.cpp:507)
2021-11-03T08:00:01.6256315Z ==7070==    by 0x3107A9: FatFile::open(FatFile*, char const*, unsigned char) (FatFile.cpp:448)
2021-11-03T08:00:01.6258461Z ==7070==    by 0x310638: FatFile::open(FatVolume*, char const*, unsigned char) (FatFile.cpp:422)
2021-11-03T08:00:01.6260848Z ==7070==    by 0x2F5187: FatVolume::exists(char const*) (FatVolume.h:86)
2021-11-03T08:00:01.6262891Z ==7070==    by 0x2F572A: sdfs::SDFSImpl::exists(char const*) (SDFS.h:85)
2021-11-03T08:00:01.6264840Z ==7070==    by 0x2D32F2: fs::FS::exists(char const*) (FS.cpp:379)
2021-11-03T08:00:01.6266761Z ==7070==    by 0x192CFD: sdfs_test::____C_A_T_C_H____T_E_S_T____110() (test_fs.inc:119)
2021-11-03T08:00:01.6268827Z ==7070==    by 0x24F4BC: Catch::FreeFunctionTestCase::invoke() const (catch.hpp:5874)
2021-11-03T08:00:01.6270938Z ==7070==    by 0x220F53: Catch::TestCase::invoke() const (catch.hpp:6779)
2021-11-03T08:00:01.6273049Z ==7070==    by 0x24A24F: Catch::RunContext::invokeActiveTestCase() (catch.hpp:5473)
2021-11-03T08:00:01.6275817Z ==7070==    by 0x249A8D: Catch::RunContext::runCurrentTest(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&) (catch.hpp:5445)
2021-11-03T08:00:01.6277717Z ==7070==    by 0x246DCB: Catch::RunContext::runTest(Catch::TestCase const&) (catch.hpp:5284)
2021-11-03T08:00:01.6279120Z ==7070==  Uninitialised value was created by a stack allocation
2021-11-03T08:00:01.6280534Z ==7070==    at 0x310664: FatFile::open(FatFile*, char const*, unsigned char) (FatFile.cpp:425)
2021-11-03T08:00:01.6281714Z ==7070== 
````