### PR TITLE
Allow Arduino flags to be set externally

### DIFF
--- a/src/SdFatConfig.h
+++ b/src/SdFatConfig.h
@@ -87,13 +87,18 @@
 #define DESTRUCTOR_CLOSES_FILE 0
 #endif  // DESTRUCTOR_CLOSES_FILE
 //------------------------------------------------------------------------------
-
+#ifndef ENABLE_ARDUINO_FEATURES
 /** For Debug - must be one */
 #define ENABLE_ARDUINO_FEATURES 1
+#endif
+#ifndef ENABLE_ARDUINO_SERIAL
 /** For Debug - must be one */
 #define ENABLE_ARDUINO_SERIAL 1
+#endif
+#ifndef ENABLE_ARDUINO_STRING
 /** For Debug - must be one */
 #define ENABLE_ARDUINO_STRING 1
+#endif
 //------------------------------------------------------------------------------
 #if ENABLE_ARDUINO_FEATURES
 #include "Arduino.h"


### PR DESCRIPTION
Currently in SdFatConfig.h, the arduino-related flags are hard coded to "1".

In my usecase, I'm trying to use sdfat without the Arduino framework. These proposed changes should allow me to do so without having any effect on Arduino users.